### PR TITLE
Fixes when including with CMake add_subdirectory()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(DOCS_ONLY)
   set(REQUIRED_STRING "")
 endif()
 
-if(NOT ${CERBERUS_SKIP_YAML_CPP_PACKAGE_SEARCH})
+if(${CERBERUS_CPP_FIND_YAML_CPP})
   find_package(yaml-cpp 0.6 ${REQUIRED_STRING})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
+cmake_minimum_required(VERSION 3.11)
+cmake_policy(SET CMP0077 NEW)
+
 project(cerberus-cpp LANGUAGES CXX)
 
-cmake_minimum_required(VERSION 3.11)
+set(CERBERUS_CPP_MAIN_PROJECT OFF)
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  set(CERBERUS_CPP_MAIN_PROJECT ON)
+endif()
+
+option(CERBERUS_CPP_FIND_YAML_CPP "Enable find_package(yaml-cpp)." ON)
+option(CERBERUS_CPP_INSTALL "Enable generation of cerberus-cpp install targets" ${CERBERUS_CPP_MAIN_PROJECT})
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -13,7 +22,9 @@ if(DOCS_ONLY)
   set(REQUIRED_STRING "")
 endif()
 
-find_package(yaml-cpp 0.6 ${REQUIRED_STRING})
+if(NOT ${CERBERUS_SKIP_YAML_CPP_PACKAGE_SEARCH})
+  find_package(yaml-cpp 0.6 ${REQUIRED_STRING})
+endif()
 
 # Add library target that can be linked against
 add_library(cerberus-cpp INTERFACE)
@@ -41,24 +52,26 @@ endif()
 # Installation rules
 include(GNUInstallDirs)
 
-install(
-  TARGETS cerberus-cpp
-  EXPORT cerberus-cpp-config
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
+if (CERBERUS_CPP_INSTALL)
+  install(
+    TARGETS cerberus-cpp
+    EXPORT cerberus-cpp-config
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
 
-install(
-  EXPORT cerberus-cpp-config
-  NAMESPACE cerberus-cpp::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cerberus-cpp
-)
+  install(
+    EXPORT cerberus-cpp-config
+    NAMESPACE cerberus-cpp::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cerberus-cpp
+  )
 
-install(
-  DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+  install(
+    DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+endif()
 
 include(FeatureSummary)
 feature_summary(WHAT ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(cerberus-cpp INTERFACE)
 target_include_directories(
   cerberus-cpp
   INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include/>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(cerberus-cpp INTERFACE yaml-cpp)
@@ -43,7 +43,7 @@ add_library(cerberus-cpp::cerberus-cpp ALIAS cerberus-cpp)
 add_subdirectory(doc)
 
 # Add the testing subdirectories
-if(EXISTS ${CMAKE_SOURCE_DIR}/ext/Catch2/CMakeLists.txt)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/ext/Catch2/CMakeLists.txt)
   include(CTest)
   add_subdirectory(ext/Catch2)
   add_subdirectory(test)


### PR DESCRIPTION
With the included fixes, I can now include this repository as a git submodule of my own project and include it in my build directly using `add_subdirectory()`.


`my_project/external/CMakeLists.txt`
```cmake
set(CERBERUS_CPP_FIND_YAML_CPP OFF)
add_subdirectory(cerberus-cpp EXCLUDE_FROM_ALL)

add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
target_include_directories(yaml-cpp SYSTEM INTERFACE
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/yaml-cpp/include>
)
```

`my_project/src/CMakeLists.txt`
```cmake
add_executable(main main.cpp)
target_link_libraries(main
    PRIVATE
        yaml-cpp
        cerberus-cpp
)
```